### PR TITLE
🐧 Specifies absolute path for flatpak-spawn command

### DIFF
--- a/lib/src/media/media_details.dart
+++ b/lib/src/media/media_details.dart
@@ -688,7 +688,7 @@ class _MediaDetailsViewState extends ConsumerState<MediaDetailsView> {
           );
         },
         onLongPress: () {
-          Process.start("flatpak-spawn", <String>[_mpvPlayer, "--start=${recording.position}", d.fullPathMedia!]);
+          Process.start("/usr/bin/flatpak-spawn", <String>[_mpvPlayer, "--start=${recording.position}", d.fullPathMedia!]);
         },
         tooltip: "Local file is downloaded. Click to play.",
         icon: const Icon(Icons.download_done),


### PR DESCRIPTION
Ensures consistent process execution by invoking the flatpak-spawn binary using its absolute path. Prevents issues on systems where the command might not be in the default PATH.