### PR TITLE
🛡️ Hides copy URL button when fragment URL is empty

### DIFF
--- a/lib/src/media/media_details.dart
+++ b/lib/src/media/media_details.dart
@@ -446,13 +446,15 @@ class _MediaDetailsViewState extends ConsumerState<MediaDetailsView> {
             ),
           ),
           DataCell(
-            IconButton(
-              onPressed: () {
-                copyToClipboard(context, f.url);
-              },
-              tooltip: "Copy URL this fragment into clipboard",
-              icon: _copyURLIcon,
-            ),
+            f.url != ""
+                ? IconButton(
+                    onPressed: () {
+                      copyToClipboard(context, f.url);
+                    },
+                    tooltip: "Copy URL this fragment into clipboard",
+                    icon: _copyURLIcon,
+                  )
+                : const SizedBox.shrink(),
           ),
           DataCell(Text(f.ext)),
           DataCell(Text(f.resolution)),
@@ -811,4 +813,3 @@ Future<void> copyToClipboard(BuildContext context, String textData) async {
     ));
   });
 }
-


### PR DESCRIPTION
Prevents displaying the copy URL button for fragments that lack a URL to avoid confusing or unnecessary UI elements. Enhances user experience by only showing actionable buttons.