### PR TITLE
🌐 Handles web platform by marking data/media directories unavailable

### DIFF
--- a/lib/src/settings/settings_provider.dart
+++ b/lib/src/settings/settings_provider.dart
@@ -23,6 +23,10 @@ Map<double, String> speedRates = {
 };
 
 Future<String> _dataDir(String srcDir) async {
+  if (UniversalPlatform.isWeb) {
+    return "<unavailable>";
+  }
+
   if (srcDir == "") {
     final documents = await getApplicationDocumentsDirectory();
     if (UniversalPlatform.isDesktop) {
@@ -43,6 +47,10 @@ Future<String> _dataDir(String srcDir) async {
 }
 
 Future<String> _mediaDir(String srcDir) async {
+  if (UniversalPlatform.isWeb) {
+    return "<unavailable>";
+  }
+
   if (srcDir == "") {
     final documents = await getApplicationDocumentsDirectory();
     if (UniversalPlatform.isDesktop) {


### PR DESCRIPTION
Prevents attempts to access data and media directories on web platforms by returning a placeholder string, avoiding unsupported operations and potential runtime errors.