### PR TITLE
🔧 Removes explicit hero tags from scroll buttons

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,3 +19,4 @@ void main() async {
 
   runApp(const ProviderScope(child: MyApp()));
 }
+

--- a/lib/src/media/media_list.dart
+++ b/lib/src/media/media_list.dart
@@ -241,12 +241,12 @@ class _MediaListViewRiverpodState extends ConsumerState<MediaListViewRiverpod> {
             child: const Icon(Icons.content_paste_go_rounded),
           ),
           FloatingActionButton.small(
-            heroTag: "up",
+            // heroTag: "up",
             onPressed: _scrollUp,
             child: const Icon(Icons.arrow_upward),
           ),
           FloatingActionButton.small(
-            heroTag: "down",
+            // heroTag: "down",
             onPressed: _scrollDown,
             child: const Icon(Icons.arrow_downward),
           ),


### PR DESCRIPTION
Eliminates manual hero tag assignment for scroll-related floating action buttons to avoid potential hero tag conflicts and streamline widget usage.