### PR TITLE
🔒 Makes MPV socket path instance-specific

### DIFF
--- a/lib/src/media/media_details.dart
+++ b/lib/src/media/media_details.dart
@@ -42,8 +42,6 @@ const _playMpvIcon = Icon(Icons.play_circle);
 //const _ffmpeg = "/app/bin/ffmpeg";
 const _mpvPlayer = "/app/bin/mpv";
 
-const _mpvSocketPath = '/tmp/mpvsocket';
-
 class MediaDetailsView extends ConsumerStatefulWidget {
   const MediaDetailsView({
     super.key,
@@ -62,12 +60,15 @@ class MediaDetailsView extends ConsumerStatefulWidget {
 class _MediaDetailsViewState extends ConsumerState<MediaDetailsView> {
   String? title;
   StreamSubscription? _updatePullSubs;
+  late String _mpvSocketPath;
 
   static const _updatePullPeriod = Duration(seconds: 3);
 
   @override
   void initState() {
     super.initState();
+
+    _mpvSocketPath = "/tmp/${widget.id}";
 
     _pullRefresh();
 

--- a/lib/src/media/mpv.dart
+++ b/lib/src/media/mpv.dart
@@ -2,20 +2,26 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 
-//const mpvSocketPath = '/tmp/mpvsocket';
+const _timeout = Duration(seconds: 1);
 
 void getMpvPlaybackPosition(String socketPath, void Function(double? pos) callback) async {
   try {
-    final socket = await Socket.connect(InternetAddress(socketPath, type: InternetAddressType.unix), 0);
+    final socket = await Socket.connect(InternetAddress(socketPath, type: InternetAddressType.unix), 0, timeout: _timeout);
     // mpv IPC: {"command": ["get_property", "playback-time"]}
+    debugPrint("Connected to mpv IPC socket at $socketPath");
     socket.write('{"command": ["get_property", "playback-time"]}\n');
     await socket.flush();
 
     socket.listen((data) {
       final json = jsonDecode(utf8.decode(data));
       callback(json['data'] is double ? json['data'] : null);
+    }, onDone: () {
+      debugPrint("onDone $socketPath closed");
+    }, onError: (error) {
+      debugPrint("onError: $error");
     });
     await socket.close();
+    debugPrint("$socketPath closed");
   } catch (e) {
     debugPrint('mpv IPC error: $e');
   }


### PR DESCRIPTION
Updates socket path assignment to use a unique value per widget instance, preventing conflicts when multiple instances are active and improving process isolation.

 #70