### PR TITLE
🧹 Refactors media details tables into separate widgets

### DIFF
--- a/lib/src/media/downloads_table.dart
+++ b/lib/src/media/downloads_table.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import '../model/download.dart';
+import '../model/recording_info.dart';
+import 'download_details.dart';
+import 'format.dart';
+
+class DownloadsTable extends StatelessWidget {
+  final RecordingInfo recording;
+  final List<Download> downloads;
+  final void Function(BuildContext, RecordingInfo, Download) recordView;
+  final void Function(BuildContext, String) startPreparation;
+  final Widget Function(BuildContext, RecordingInfo, Download) buildActions;
+  final Widget Function(BuildContext, RecordingInfo, Download) buildLocalActions;
+
+  const DownloadsTable({
+    super.key,
+    required this.recording,
+    required this.downloads,
+    required this.recordView,
+    required this.startPreparation,
+    required this.buildActions,
+    required this.buildLocalActions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const splitter = LineSplitter();
+
+    var rows = List<DataRow>.generate(downloads.length, (i) {
+      final d = downloads[i];
+      final ll = splitter.convert(d.progress);
+      final pr = ll.isEmpty ? '' : ll[ll.length - 1];
+      final hr = fileSizeHumanReadable(d.size);
+      var opacity = 0.25;
+      switch (d.status) {
+        case "stale":
+          opacity = 0.5;
+        case "new":
+        case "in_progress":
+          opacity = 0.75;
+        case "ready":
+          opacity = 1.0;
+      }
+
+      return DataRow(cells: [
+        DataCell(
+          onTap: () {
+            if (d.status == "ready") {
+              recordView(context, recording, d);
+            } else if (d.status == "stale") {
+              startPreparation(context, d.formatId);
+            }
+          },
+          Opacity(
+            opacity: opacity,
+            child: Tooltip(
+              message: "${d.filename} tap to play in embedding player",
+              child: Text(d.formatId),
+            ),
+          ),
+        ),
+        DataCell(Row(
+          children: [
+            buildActions(context, recording, d),
+            buildLocalActions(context, recording, d),
+          ],
+        )),
+        DataCell(Opacity(opacity: opacity, child: Text(d.resolution))),
+        DataCell(Opacity(opacity: opacity, child: Text(d.fps != null ? "${d.fps}" : ""))),
+        DataCell(Opacity(
+          opacity: opacity,
+          child: Row(
+            children: [
+              Visibility(visible: d.hasAudio, child: const Icon(Icons.audiotrack_rounded)),
+              Visibility(visible: d.hasVideo, child: const Icon(Icons.videocam_rounded)),
+            ],
+          ),
+        )),
+        DataCell(Opacity(opacity: opacity, child: Text(d.size == 0 ? '' : hr))),
+        DataCell(
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (BuildContext context) => DownloadDetailsView(downloadId: d.id)),
+            );
+          },
+          Opacity(opacity: opacity, child: Text(pr)),
+        ),
+      ]);
+    });
+
+    const headerStyle = TextStyle(
+      fontStyle: FontStyle.italic,
+      fontWeight: FontWeight.bold,
+    );
+
+    return downloads.isEmpty
+        ? const Text(
+            "No downloads for recording",
+            style: TextStyle(fontStyle: FontStyle.italic),
+          )
+        : Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    "Files for this recording",
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  DataTable(
+                    columnSpacing: 12,
+                    columns: const [
+                      DataColumn(label: Expanded(child: Text("format", style: headerStyle))),
+                      DataColumn(label: Expanded(child: Text("", style: headerStyle))),
+                      DataColumn(label: Expanded(child: Text("resolution", style: headerStyle))),
+                      DataColumn(label: Expanded(child: Text("fps", style: headerStyle))),
+                      DataColumn(label: Expanded(child: Text("", style: headerStyle))),
+                      DataColumn(label: Expanded(child: Text("size", style: headerStyle))),
+                      DataColumn(label: Expanded(child: Text("", style: headerStyle))),
+                    ],
+                    rows: rows,
+                  ),
+                ],
+              ),
+            ),
+          );
+  }
+}

--- a/lib/src/media/formats_table.dart
+++ b/lib/src/media/formats_table.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+import '../model/recording_info.dart';
+import 'media_details.dart';
+
+const downloadFormatIcon = Icon(Icons.start);
+const copyURLIcon = Icon(Icons.copy);
+
+class FormatsTable extends StatelessWidget {
+  final RecordingInfo recording;
+  final void Function(BuildContext, String) startPreparation;
+
+  const FormatsTable({
+    super.key,
+    required this.recording,
+    required this.startPreparation,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    List<DataRow> rows = [];
+
+    for (int i = 0; i < recording.formats!.length; i++) {
+      var f = recording.formats![i];
+      rows.add(DataRow(
+        cells: <DataCell>[
+          DataCell(
+            IconButton(
+              onPressed: () {
+                startPreparation(context, "${f.id}+ba");
+              },
+              tooltip: "Download this format and the best audio on the server (prepare for viewing)",
+              icon: downloadFormatIcon,
+            ),
+          ),
+          DataCell(
+            onTap: () {
+              startPreparation(context, f.id);
+            },
+            Tooltip(
+              message: "Download exact this format (prepare this format for viewing)",
+              child: Text(f.id),
+            ),
+          ),
+          DataCell(
+            f.url != ""
+                ? IconButton(
+                    onPressed: () {
+                      copyToClipboard(context, f.url);
+                    },
+                    tooltip: "Copy URL this fragment into clipboard",
+                    icon: copyURLIcon,
+                  )
+                : const SizedBox.shrink(),
+          ),
+          DataCell(Text(f.ext)),
+          DataCell(Text(f.resolution)),
+          DataCell(Visibility(visible: f.fps != 0, child: Text("${f.fps}"))),
+          DataCell(Visibility(visible: f.hasAudio, child: const Icon(Icons.audiotrack_rounded))),
+          DataCell(Visibility(visible: f.hasVideo, child: const Icon(Icons.videocam_rounded))),
+        ],
+      ));
+    }
+
+    const headerStyle = TextStyle(
+      fontStyle: FontStyle.italic,
+      fontWeight: FontWeight.bold,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            "Common available formats:",
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          TextButton.icon(
+            onPressed: () {
+              startPreparation(context, "ba");
+            },
+            icon: const Icon(Icons.audiotrack_rounded),
+            label: const Text("Best audio (ba)"),
+          ),
+          const Text(
+            "Available formats:",
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              columnSpacing: 12,
+              columns: const <DataColumn>[
+                DataColumn(label: Expanded(child: Text("", style: headerStyle))),
+                DataColumn(label: Expanded(child: Text("id", style: headerStyle))),
+                DataColumn(label: Expanded(child: Text("URL", style: headerStyle))),
+                DataColumn(label: Expanded(child: Text("ext", style: headerStyle))),
+                DataColumn(label: Expanded(child: Text("resolution", style: headerStyle))),
+                DataColumn(label: Expanded(child: Text("fps", style: headerStyle))),
+                DataColumn(label: Expanded(child: Text("", style: headerStyle))),
+                DataColumn(label: Expanded(child: Text("", style: headerStyle))),
+              ],
+              rows: rows,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Moves downloads and formats tables into dedicated stateless widgets to improve code modularity, readability, and maintainability. Simplifies the main media details view by delegating table rendering and logic to new reusable components.