### PR TITLE
🎛️ Refactors player controls into a reusable widget

### DIFF
--- a/lib/src/media/downloads_table.dart
+++ b/lib/src/media/downloads_table.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../model/download.dart';
 import '../model/recording_info.dart';
 import 'download_details.dart';
 import 'format.dart';
 
-class DownloadsTable extends StatelessWidget {
+class DownloadsTable extends ConsumerWidget {
   final RecordingInfo recording;
   final List<Download> downloads;
   final void Function(BuildContext, RecordingInfo, Download) recordView;
@@ -24,7 +25,7 @@ class DownloadsTable extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     const splitter = LineSplitter();
 
     var rows = List<DataRow>.generate(downloads.length, (i) {

--- a/lib/src/media/media_kit/recording_play.dart
+++ b/lib/src/media/media_kit/recording_play.dart
@@ -329,7 +329,12 @@ class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMedi
                       ),
                       Padding(
                         padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
-                        child: _buildControls(context),
+                        child: PlayerControls(
+                          player: _player,
+                          onSeek: (duration) => _seek(duration),
+                          onRewind: (interval) => _rewind(interval),
+                          ref: ref,
+                        ),
                       ),
                       Container(
                         alignment: Alignment.centerLeft,
@@ -395,20 +400,34 @@ class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMedi
       ),
     );
   }
+}
 
-  Widget _buildControls(BuildContext context) {
+class PlayerControls extends StatelessWidget {
+  final Player player;
+  final void Function(Duration) onSeek;
+  final void Function(Duration) onRewind;
+  final WidgetRef ref;
+
+  const PlayerControls({
+    super.key,
+    required this.player,
+    required this.onSeek,
+    required this.onRewind,
+    required this.ref,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       children: [
         ProgressBar(
           progressBarColor: Theme.of(context).colorScheme.primary,
           timeLabelLocation: TimeLabelLocation.sides,
-          progress: _player.state.position,
-          total: _player.state.duration,
+          progress: player.state.position,
+          total: player.state.duration,
           timeLabelType: TimeLabelType.remainingTime,
-          buffered: _player.state.buffer,
-          onSeek: (duration) {
-            _seek(duration);
-          },
+          buffered: player.state.buffer,
+          onSeek: onSeek,
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -416,61 +435,53 @@ class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMedi
           children: [
             TextButton(
               onLongPress: () {
-                _rewind(-const Duration(minutes: 5));
+                onRewind(-const Duration(minutes: 5));
               },
               onPressed: () {
-                _rewind(-const Duration(minutes: 1));
+                onRewind(-const Duration(minutes: 1));
               },
               child: const Icon(Icons.fast_rewind),
             ),
             TextButton(
               onLongPress: () {
-                _rewind(-const Duration(seconds: 30));
+                onRewind(-const Duration(seconds: 30));
               },
               onPressed: () {
-                _rewind(-const Duration(seconds: 15));
+                onRewind(-const Duration(seconds: 15));
               },
               child: const Icon(Icons.fast_rewind),
             ),
-            if (_player.state.playing)
+            if (player.state.playing)
               TextButton(
                 onPressed: () {
-                  _player.playOrPause();
+                  player.playOrPause();
                 },
-                child: const Icon(
-                  Icons.pause,
-                ),
+                child: const Icon(Icons.pause),
               ),
-            if (!_player.state.playing)
+            if (!player.state.playing)
               TextButton(
                 onPressed: () {
-                  _player.playOrPause();
+                  player.playOrPause();
                 },
-                child: const Icon(
-                  Icons.play_arrow,
-                ),
+                child: const Icon(Icons.play_arrow),
               ),
             TextButton(
               onLongPress: () {
-                _rewind(const Duration(seconds: 30));
+                onRewind(const Duration(seconds: 30));
               },
               onPressed: () {
-                _rewind(const Duration(seconds: 15));
+                onRewind(const Duration(seconds: 15));
               },
-              child: const Icon(
-                Icons.fast_forward,
-              ),
+              child: const Icon(Icons.fast_forward),
             ),
             TextButton(
               onLongPress: () {
-                _rewind(const Duration(minutes: 5));
+                onRewind(const Duration(minutes: 5));
               },
               onPressed: () {
-                _rewind(const Duration(minutes: 1));
+                onRewind(const Duration(minutes: 1));
               },
-              child: const Icon(
-                Icons.fast_forward,
-              ),
+              child: const Icon(Icons.fast_forward),
             ),
           ],
         ),
@@ -480,7 +491,7 @@ class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMedi
             value: ref.watch(settingsNotifierProvider.select((s) => s.value?.playerSpeed)),
             onChanged: (value) {
               ref.read(settingsNotifierProvider.notifier).updatePlayerSpeed(value ?? 1.0);
-              _player.setRate(value ?? 1.0);
+              player.setRate(value ?? 1.0);
             },
             items: [
               for (final e in speedRates.entries) DropdownMenuItem(value: e.key, child: Text(e.value)),
@@ -491,4 +502,3 @@ class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMedi
     );
   }
 }
-


### PR DESCRIPTION
Extracts playback controls into a separate stateless widget to improve code organization and reusability. Enables cleaner component structure and prepares for potential future enhancements or reuse of controls in other parts of the UI.

Animation freezes while switching screens #62