### PR TITLE
🚀 Improves build performance and enables multidex support

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "uno.almaz.ilovlya"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
@@ -55,6 +54,12 @@ android {
         // targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled true
+    }
+
+    dexOptions {
+        javaMaxHeapSize "4g"
+        preDexLibraries false
     }
 
     buildTypes {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,6 @@
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.daemon=true


### PR DESCRIPTION
Enables multidex to support large method counts and configures DexOptions for better memory usage during builds.

Increases JVM memory allocation and activates Gradle parallel build features to speed up builds and reduce out-of-memory errors.