### PR TITLE
Fix Bluetooth play/pause button at non-standard playback speeds

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   final session = await AudioSession.instance;
-  await session.configure(const AudioSessionConfiguration.speech());
+  await session.configure(const AudioSessionConfiguration.music());
 
   // media_kit
   MediaKit.ensureInitialized();

--- a/lib/src/media/media_kit/audio_handler.dart
+++ b/lib/src/media/media_kit/audio_handler.dart
@@ -1,4 +1,6 @@
 import 'package:audio_service/audio_service.dart';
+import 'package:audio_session/audio_session.dart';
+import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:universal_platform/universal_platform.dart';
 
@@ -19,6 +21,8 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
     osc: false,
   ));
 
+  bool _wasPlayingBeforeInterruption = false;
+
   static void init() async {
     if (UniversalPlatform.isDesktop) {
       _handler = MKPlayerHandler();
@@ -33,6 +37,47 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
         androidNotificationOngoing: true,
       ),
     );
+
+    // Setup audio session interruption handling for iOS
+    await _handler._setupAudioSessionHandling();
+  }
+
+  Future<void> _setupAudioSessionHandling() async {
+    final session = await AudioSession.instance;
+
+    // Listen to audio interruptions (phone calls, alarms, etc.)
+    session.interruptionEventStream.listen((event) {
+      debugPrint('Audio interruption event: ${event.type}, begin: ${event.begin}');
+
+      if (event.begin) {
+        // Interruption began (phone call, alarm, etc.)
+        if (_player.state.playing) {
+          _wasPlayingBeforeInterruption = true;
+          _player.pause();
+          debugPrint('Paused playback due to interruption');
+        }
+      } else {
+        // Interruption ended - resume playback if it was playing before
+        if (_wasPlayingBeforeInterruption) {
+          // Add small delay to ensure audio session is ready
+          Future.delayed(const Duration(milliseconds: 500), () {
+            if (_wasPlayingBeforeInterruption) {
+              _player.play();
+              debugPrint('Resumed playback after interruption');
+            }
+            _wasPlayingBeforeInterruption = false;
+          });
+        }
+      }
+    });
+
+    // Listen to becoming noisy events (headphones unplugged)
+    session.becomingNoisyEventStream.listen((_) {
+      debugPrint('Becoming noisy - pausing playback');
+      if (_player.state.playing) {
+        _player.pause();
+      }
+    });
   }
 
   void playRecording(RecordingInfo recording, Download download, Uri thumbnailUrl) {

--- a/lib/src/media/media_kit/audio_handler.dart
+++ b/lib/src/media/media_kit/audio_handler.dart
@@ -106,6 +106,9 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
     player.stream.buffer.listen((event) {
       _handler.updatePlaybackState();
     });
+    player.stream.rate.listen((event) {
+      _handler.updatePlaybackState();
+    });
   }
 
   void updatePlaybackState() {
@@ -150,13 +153,13 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
 
   @override
   Future<void> play() async {
-    _player.playOrPause();
+    _player.play();
     super.play();
   }
 
   @override
   Future<void> pause() async {
-    _player.playOrPause();
+    _player.pause();
     super.pause();
   }
 

--- a/lib/src/media/media_kit/audio_handler.dart
+++ b/lib/src/media/media_kit/audio_handler.dart
@@ -64,19 +64,24 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
   }
 
   void updatePlaybackState() {
+    // If mediaItem is null, set state to idle (removes lock screen notification)
+    final bool hasMedia = mediaItem.value != null;
+
     _handler.playbackState.add(PlaybackState(
-      processingState: mediaItem.value == null ? AudioProcessingState.idle : AudioProcessingState.ready,
-      controls: [
+      processingState: hasMedia
+          ? AudioProcessingState.ready
+          : AudioProcessingState.idle,
+      controls: hasMedia ? [
         MediaControl.rewind,
         if (_player.state.playing) MediaControl.pause else MediaControl.play,
         MediaControl.fastForward,
-      ],
-      systemActions: const {
+      ] : [],
+      systemActions: hasMedia ? const {
         MediaAction.seek,
         MediaAction.playPause,
         MediaAction.seekForward,
         MediaAction.seekBackward,
-      },
+      } : {},
       playing: _player.state.playing,
       updatePosition: _player.state.position,
       bufferedPosition: _player.state.buffer,
@@ -90,6 +95,12 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
 
     _handler.mediaItem.add(null);
     //_handler.playbackState.add(_handler.playbackState.value.copyWith());
+  }
+
+  /// Clear media session (removes lock screen notification)
+  static void clearMediaSession() {
+    _handler.mediaItem.add(null);
+    _handler.updatePlaybackState();
   }
 
   @override
@@ -115,6 +126,11 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
     // final session = await AudioSession.instance;
     // await session.setActive(false);
     _player.stop();
+
+    // Clear the media item to remove lock screen notification
+    _handler.mediaItem.add(null);
+    _handler.updatePlaybackState();
+
     super.stop();
   }
 }

--- a/lib/src/media/media_kit/recording_play.dart
+++ b/lib/src/media/media_kit/recording_play.dart
@@ -142,6 +142,7 @@ class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMedi
   @override
   void deactivate() async {
     MKPlayerHandler.player.stop();
+    MKPlayerHandler.clearMediaSession(); // Clear lock screen notification
     _positionSendSubs?.cancel();
     super.deactivate();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_service
-      sha256: f6c8191bef6b843da34675dd0731ad11d06094c36b691ffcf3148a4feb2e585f
+      sha256: cb122c7c2639d2a992421ef96b67948ad88c5221da3365ccef1031393a76e044
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.16"
+    version: "0.18.18"
   audio_service_platform_interface:
     dependency: transitive
     description:
@@ -109,18 +109,18 @@ packages:
     dependency: transitive
     description:
       name: audio_service_web
-      sha256: "4cdc2127cd4562b957fb49227dc58e3303fafb09bde2573bc8241b938cf759d9"
+      sha256: b8ea9243201ee53383157fbccf13d5d2a866b5dda922ec19d866d1d5d70424df
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   audio_session:
     dependency: "direct main"
     description:
       name: audio_session
-      sha256: b2a26ba8b7efa1790d6460e82971fde3e398cfbe2295df9dea22f3499d2c12a7
+      sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.23"
+    version: "0.1.25"
   audio_video_progress_bar:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Ilovlya Media Center
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 3.0.2
+version: 3.0.3
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -12,7 +12,7 @@ environment:
 dependencies:
   animated_search_bar: ^2.7.1
   app_links: ^6.0.2
-  audio_service: ^0.18.13
+  audio_service: ^0.18.18
   audio_video_progress_bar: ^2.0.2
   background_downloader: ^9.2.2
   device_info_plus: ^11.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Ilovlya Media Center
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 3.0.1
+version: 3.0.2
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## Changes

This PR includes improvements to audio playback controls and session handling:

### 1. Lock screen notification handling (#89)
**Commit:** b348d4b 🔒 Improves lock screen notification handling on stop
- Fixed notification persistence on lock screen after playback stops
- Improved media session cleanup

### 2. Audio session interruption handling (#89)
**Commit:** d33ef6f 🔊 Improves audio session handling for interruptions
- Enhanced handling of audio interruptions (calls, other apps)
- Better audio session configuration

### 3. Version update
**Commit:** 7d4b9bd 🔖 Updates project version to 3.0.2
- Bumped version to 3.0.2

### 4. Bluetooth controls at non-standard speeds (#91)
**Commit:** ceec5e3 🔊 Updates audio handling and dependencies
- Fixed Bluetooth play/pause button not working at playback speeds > 1.0x
- Updated `audio_service` dependency from `^0.18.13` to `^0.18.18`
- Added rate change listener to update playback state when speed changes
- Changed `play()` and `pause()` methods to use explicit calls

**Root cause:** iOS requires both `MPNowPlayingInfoPropertyPlaybackRate` and `MPNowPlayingInfoPropertyDefaultPlaybackRate` for proper Bluetooth functionality at non-standard speeds. The fix was merged in [audio_service PR #1017](https://github.com/ryanheise/audio_service/pull/1017).

## Testing
✅ Lock screen notifications properly cleared on stop
✅ Audio interruptions handled correctly
✅ Bluetooth play/pause button works at speeds: 1.0x, 1.25x, 1.5x, 2.0x
✅ On-screen controls continue working properly

Fixes #89
Fixes #91