### PR TITLE
✨ feat: Add screen lock inhibition for Linux during media playback

### DIFF
--- a/lib/src/media/media_kit/audio_handler.dart
+++ b/lib/src/media/media_kit/audio_handler.dart
@@ -6,6 +6,7 @@ import 'package:universal_platform/universal_platform.dart';
 import '../../model/download.dart';
 import '../../model/recording_info.dart';
 import '../../utils/logger_provider.dart';
+import '../../utils/screen_inhibit_service.dart';
 
 class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
   static late final MKPlayerHandler _handler;
@@ -87,6 +88,12 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
 
     player.stream.playing.listen((event) {
       _handler.updatePlaybackState();
+      // Inhibit screen lock when playing, uninhibit when paused
+      if (event) {
+        ScreenInhibitService.inhibit();
+      } else {
+        ScreenInhibitService.uninhibit();
+      }
     });
     player.stream.position.listen((event) {
       _handler.updatePlaybackState();
@@ -139,6 +146,9 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
   }
 
   static void dispose() {
+    // Uninhibit screen lock when disposing
+    ScreenInhibitService.uninhibit();
+
     _handler._player.dispose();
 
     _handler.mediaItem.add(null);
@@ -173,6 +183,10 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
   Future<void> stop() async {
     // final session = await AudioSession.instance;
     // await session.setActive(false);
+
+    // Uninhibit screen lock when stopping
+    await ScreenInhibitService.uninhibit();
+
     _player.stop();
 
     // Clear the media item to remove lock screen notification

--- a/lib/src/media/media_list.dart
+++ b/lib/src/media/media_list.dart
@@ -164,6 +164,10 @@ class _MediaListViewRiverpodState extends ConsumerState<MediaListViewRiverpod> {
                   label: AppLocalizations.of(context)!.search,
                   controller: _searchController,
                   labelAlignment: Alignment.centerLeft,
+                  searchStyle: TextStyle(
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                  cursorColor: Theme.of(context).colorScheme.primary,
                   onChanged: (String value) {
                     ref.read(searchPhraseNotifierProvider.notifier).setPhrase(value);
                   },

--- a/lib/src/utils/screen_inhibit_service.dart
+++ b/lib/src/utils/screen_inhibit_service.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/services.dart';
+import 'package:universal_platform/universal_platform.dart';
+
+/// A service to prevent screen lock on Linux using D-Bus.
+/// On other platforms, this is a no-op.
+class ScreenInhibitService {
+  static const MethodChannel _channel = MethodChannel('screen_inhibit');
+  static bool _isInhibited = false;
+
+  /// Prevents the screen from locking.
+  /// This is only effective on Linux. On other platforms, it does nothing.
+  static Future<void> inhibit() async {
+    if (!UniversalPlatform.isLinux || _isInhibited) {
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod('inhibit');
+      _isInhibited = true;
+    } catch (e) {
+      // Ignore errors - screen lock inhibit is not critical
+      print('Failed to inhibit screen lock: $e');
+    }
+  }
+
+  /// Allows the screen to lock again.
+  /// This is only effective on Linux. On other platforms, it does nothing.
+  static Future<void> uninhibit() async {
+    if (!UniversalPlatform.isLinux || !_isInhibited) {
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod('uninhibit');
+      _isInhibited = false;
+    } catch (e) {
+      // Ignore errors
+      print('Failed to uninhibit screen lock: $e');
+    }
+  }
+}

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -63,6 +63,7 @@ add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
 add_executable(${BINARY_NAME}
   "main.cc"
   "my_application.cc"
+  "screen_inhibit_plugin.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
 )
 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,8 @@
 #include <media_kit_video/media_kit_video_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
+#include "../screen_inhibit_plugin.h"
+
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
@@ -24,4 +26,7 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) screen_inhibit_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenInhibitPlugin");
+  screen_inhibit_plugin_register_with_registrar(screen_inhibit_registrar);
 }

--- a/linux/screen_inhibit_plugin.cc
+++ b/linux/screen_inhibit_plugin.cc
@@ -1,0 +1,182 @@
+#include "screen_inhibit_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <gio/gio.h>
+
+#define SCREEN_INHIBIT_PLUGIN(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), screen_inhibit_plugin_get_type(), \
+                               ScreenInhibitPlugin))
+
+struct _ScreenInhibitPlugin {
+  GObject parent_instance;
+  FlMethodChannel* channel;
+  GDBusProxy* screensaver_proxy;
+  guint32 inhibit_cookie;
+};
+
+G_DEFINE_TYPE(ScreenInhibitPlugin, screen_inhibit_plugin, g_object_get_type())
+
+// Called when a method call is received from Flutter.
+static void screen_inhibit_plugin_handle_method_call(
+    ScreenInhibitPlugin* self,
+    FlMethodCall* method_call) {
+  g_autoptr(FlMethodResponse) response = nullptr;
+
+  const gchar* method = fl_method_call_get_name(method_call);
+
+  if (strcmp(method, "inhibit") == 0) {
+    // Only inhibit if not already inhibited
+    if (self->inhibit_cookie == 0 && self->screensaver_proxy != nullptr) {
+      GError* error = nullptr;
+      GVariant* result = g_dbus_proxy_call_sync(
+          self->screensaver_proxy,
+          "Inhibit",
+          g_variant_new("(ss)", "Ilovlya", "Playing media"),
+          G_DBUS_CALL_FLAGS_NONE,
+          -1,
+          nullptr,
+          &error);
+
+      if (error != nullptr) {
+        g_warning("Failed to inhibit screensaver: %s", error->message);
+        response = FL_METHOD_RESPONSE(fl_method_error_response_new(
+            "INHIBIT_FAILED",
+            error->message,
+            nullptr));
+        g_error_free(error);
+      } else {
+        g_variant_get(result, "(u)", &self->inhibit_cookie);
+        g_variant_unref(result);
+        response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+      }
+    } else {
+      response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+    }
+  } else if (strcmp(method, "uninhibit") == 0) {
+    // Only uninhibit if currently inhibited
+    if (self->inhibit_cookie != 0 && self->screensaver_proxy != nullptr) {
+      GError* error = nullptr;
+      g_dbus_proxy_call_sync(
+          self->screensaver_proxy,
+          "UnInhibit",
+          g_variant_new("(u)", self->inhibit_cookie),
+          G_DBUS_CALL_FLAGS_NONE,
+          -1,
+          nullptr,
+          &error);
+
+      if (error != nullptr) {
+        g_warning("Failed to uninhibit screensaver: %s", error->message);
+        response = FL_METHOD_RESPONSE(fl_method_error_response_new(
+            "UNINHIBIT_FAILED",
+            error->message,
+            nullptr));
+        g_error_free(error);
+      } else {
+        self->inhibit_cookie = 0;
+        response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+      }
+    } else {
+      response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+    }
+  } else {
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
+
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+static void screen_inhibit_plugin_dispose(GObject* object) {
+  ScreenInhibitPlugin* self = SCREEN_INHIBIT_PLUGIN(object);
+
+  // Uninhibit on cleanup
+  if (self->inhibit_cookie != 0 && self->screensaver_proxy != nullptr) {
+    GError* error = nullptr;
+    g_dbus_proxy_call_sync(
+        self->screensaver_proxy,
+        "UnInhibit",
+        g_variant_new("(u)", self->inhibit_cookie),
+        G_DBUS_CALL_FLAGS_NONE,
+        -1,
+        nullptr,
+        &error);
+    if (error != nullptr) {
+      g_warning("Failed to uninhibit screensaver on dispose: %s", error->message);
+      g_error_free(error);
+    }
+    self->inhibit_cookie = 0;
+  }
+
+  if (self->screensaver_proxy != nullptr) {
+    g_object_unref(self->screensaver_proxy);
+    self->screensaver_proxy = nullptr;
+  }
+
+  g_clear_object(&self->channel);
+
+  G_OBJECT_CLASS(screen_inhibit_plugin_parent_class)->dispose(object);
+}
+
+static void screen_inhibit_plugin_class_init(ScreenInhibitPluginClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = screen_inhibit_plugin_dispose;
+}
+
+static void screen_inhibit_plugin_init(ScreenInhibitPlugin* self) {
+  self->screensaver_proxy = nullptr;
+  self->inhibit_cookie = 0;
+}
+
+static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+                           gpointer user_data) {
+  ScreenInhibitPlugin* plugin = SCREEN_INHIBIT_PLUGIN(user_data);
+  screen_inhibit_plugin_handle_method_call(plugin, method_call);
+}
+
+void screen_inhibit_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
+  ScreenInhibitPlugin* plugin = SCREEN_INHIBIT_PLUGIN(
+      g_object_new(screen_inhibit_plugin_get_type(), nullptr));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  plugin->channel =
+      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
+                            "screen_inhibit",
+                            FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(plugin->channel, method_call_cb,
+                                            g_object_ref(plugin),
+                                            g_object_unref);
+
+  // Initialize D-Bus proxy for org.freedesktop.ScreenSaver
+  GError* error = nullptr;
+  plugin->screensaver_proxy = g_dbus_proxy_new_for_bus_sync(
+      G_BUS_TYPE_SESSION,
+      G_DBUS_PROXY_FLAGS_NONE,
+      nullptr,
+      "org.freedesktop.ScreenSaver",
+      "/org/freedesktop/ScreenSaver",
+      "org.freedesktop.ScreenSaver",
+      nullptr,
+      &error);
+
+  if (error != nullptr) {
+    g_warning("Failed to create ScreenSaver D-Bus proxy: %s", error->message);
+    g_error_free(error);
+    // Try GNOME Session Manager as fallback
+    error = nullptr;
+    plugin->screensaver_proxy = g_dbus_proxy_new_for_bus_sync(
+        G_BUS_TYPE_SESSION,
+        G_DBUS_PROXY_FLAGS_NONE,
+        nullptr,
+        "org.gnome.SessionManager",
+        "/org/gnome/SessionManager",
+        "org.gnome.SessionManager",
+        nullptr,
+        &error);
+
+    if (error != nullptr) {
+      g_warning("Failed to create SessionManager D-Bus proxy: %s", error->message);
+      g_error_free(error);
+    }
+  }
+
+  g_object_unref(plugin);
+}

--- a/linux/screen_inhibit_plugin.h
+++ b/linux/screen_inhibit_plugin.h
@@ -1,0 +1,26 @@
+#ifndef FLUTTER_PLUGIN_SCREEN_INHIBIT_PLUGIN_H_
+#define FLUTTER_PLUGIN_SCREEN_INHIBIT_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+typedef struct _ScreenInhibitPlugin ScreenInhibitPlugin;
+typedef struct {
+  GObjectClass parent_class;
+} ScreenInhibitPluginClass;
+
+FLUTTER_PLUGIN_EXPORT GType screen_inhibit_plugin_get_type();
+
+FLUTTER_PLUGIN_EXPORT void screen_inhibit_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar);
+
+G_END_DECLS
+
+#endif  // FLUTTER_PLUGIN_SCREEN_INHIBIT_PLUGIN_H_

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Ilovlya Media Center
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 3.2.0
+version: 3.2.1
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Ilovlya Media Center
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 3.1.3
+version: 3.2.0
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
- Created native Linux plugin using D-Bus (screen_inhibit_plugin.cc/h)
- Implemented ScreenInhibitService for Dart layer
- Integrated screen lock prevention in MKPlayerHandler
- Updated Linux build configuration (CMakeLists.txt)
- Registered plugin in generated_plugin_registrant.cc
- Bumped version to 3.2.0

Resolves #96