### PR TITLE
🐛 fix: enable hardware acceleration for Linux video playback

### DIFF
--- a/lib/src/media/media_kit/recording_play.dart
+++ b/lib/src/media/media_kit/recording_play.dart
@@ -61,7 +61,7 @@ const _positionSendPeriod = Duration(seconds: 1);
 class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMediaKitHandler> {
   // String get url => widget.download.url;
   Player get _player => MKPlayerHandler.player;
-  late final _controller = VideoController(_player, configuration: VideoControllerConfiguration(enableHardwareAcceleration: !UniversalPlatform.isLinux));
+  late final _controller = VideoController(_player, configuration: VideoControllerConfiguration(enableHardwareAcceleration: true));
   StreamSubscription? _positionSendSubs;
   Duration _rewinding = Duration.zero;
   Timer? _rewindTimer;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Ilovlya Media Center
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 3.2.1
+version: 3.2.2
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
- Enable hardware acceleration for VideoController on all platforms including Linux
- Remove conditional disabling of HW acceleration for Linux platform
- Bump version to 3.2.2

This fixes black screen issue when playing videos in Flatpak environment where software rendering was causing display problems.