### PR TITLE
⚡️ perf: eliminate list→details transition jank

### DIFF
--- a/lib/src/media/downloads_table.dart
+++ b/lib/src/media/downloads_table.dart
@@ -23,12 +23,39 @@ class DownloadsTable extends ConsumerWidget {
     required this.buildActions,
   });
 
+  // Cell padding mimicking DataTable's columnSpacing: 12 (~6px per side).
+  static Widget _cell(Widget child) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6.0, vertical: 8.0),
+        child: child,
+      );
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    const splitter = LineSplitter();
+    if (downloads.isEmpty) {
+      return Text(
+        AppLocalizations.of(context)!.noDownloadsForRecording,
+        style: const TextStyle(fontStyle: FontStyle.italic),
+      );
+    }
 
-    var rows = List<DataRow>.generate(downloads.length, (i) {
-      final d = downloads[i];
+    const splitter = LineSplitter();
+    const headerStyle = TextStyle(fontStyle: FontStyle.italic, fontWeight: FontWeight.bold);
+    final l10n = AppLocalizations.of(context)!;
+
+    // Header row (7 columns; some are visually blank like in the old DataTable).
+    final rows = <TableRow>[
+      TableRow(children: [
+        _cell(Text(l10n.formatHeader, style: headerStyle)),
+        _cell(const Text("", style: headerStyle)),
+        _cell(Text(l10n.resolutionHeader, style: headerStyle)),
+        _cell(Text(l10n.fpsHeader, style: headerStyle)),
+        _cell(const Text("", style: headerStyle)),
+        _cell(Text(l10n.sizeHeader, style: headerStyle)),
+        _cell(const Text("", style: headerStyle)),
+      ]),
+    ];
+
+    for (final d in downloads) {
       final ll = splitter.convert(d.progress);
       final pr = ll.isEmpty ? '' : ll[ll.length - 1];
       final hr = fileSizeHumanReadable(d.size);
@@ -43,13 +70,13 @@ class DownloadsTable extends ConsumerWidget {
           opacity = 1.0;
       }
 
-      // Use color opacity instead of Opacity widget for better performance
+      // Use color opacity instead of Opacity widget for better performance.
       final textColor = Theme.of(context).textTheme.bodyMedium?.color?.withValues(alpha: opacity) ?? Colors.black.withValues(alpha: opacity);
       final iconColor = Theme.of(context).iconTheme.color?.withValues(alpha: opacity) ?? Colors.black.withValues(alpha: opacity);
       final textStyle = TextStyle(color: textColor);
 
-      return DataRow(cells: [
-        DataCell(
+      rows.add(TableRow(children: [
+        _cell(InkWell(
           onTap: () {
             if (d.status == "ready") {
               recordView(context, recording, d);
@@ -57,71 +84,63 @@ class DownloadsTable extends ConsumerWidget {
               startPreparation(context, d.formatId);
             }
           },
-          Tooltip(
-            message: AppLocalizations.of(context)!.tapToPlayInEmbeddingPlayer(d.filename),
+          child: Tooltip(
+            message: l10n.tapToPlayInEmbeddingPlayer(d.filename),
             child: Text(d.formatId, style: textStyle),
           ),
-        ),
-        DataCell(buildActions(context, recording, d)),
-        DataCell(Text(d.resolution, style: textStyle)),
-        DataCell(Text(d.fps != null ? "${d.fps}" : "", style: textStyle)),
-        DataCell(
-          Row(
-            children: [
-              if (d.hasAudio) Icon(Icons.audiotrack_rounded, color: iconColor),
-              if (d.hasVideo) Icon(Icons.videocam_rounded, color: iconColor),
-            ],
-          ),
-        ),
-        DataCell(Text(d.size == 0 ? '' : hr, style: textStyle)),
-        DataCell(
+        )),
+        _cell(buildActions(context, recording, d)),
+        _cell(Text(d.resolution, style: textStyle)),
+        _cell(Text(d.fps != null ? "${d.fps}" : "", style: textStyle)),
+        _cell(Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (d.hasAudio) Icon(Icons.audiotrack_rounded, color: iconColor),
+            if (d.hasVideo) Icon(Icons.videocam_rounded, color: iconColor),
+          ],
+        )),
+        _cell(Text(d.size == 0 ? '' : hr, style: textStyle)),
+        _cell(InkWell(
           onTap: () {
             Navigator.of(context).push(
               MaterialPageRoute(builder: (BuildContext context) => DownloadDetailsView(downloadId: d.id)),
             );
           },
-          Text(pr, style: textStyle),
-        ),
-      ]);
-    });
+          child: Text(pr, style: textStyle),
+        )),
+      ]));
+    }
 
-    const headerStyle = TextStyle(
-      fontStyle: FontStyle.italic,
-      fontWeight: FontWeight.bold,
-    );
-
-    return downloads.isEmpty
-        ? Text(
-            AppLocalizations.of(context)!.noDownloadsForRecording,
-            style: const TextStyle(fontStyle: FontStyle.italic),
-          )
-        : Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    AppLocalizations.of(context)!.filesForThisRecording,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  DataTable(
-                    columnSpacing: 12,
-                    columns: [
-                      DataColumn(label: Expanded(child: Text(AppLocalizations.of(context)!.formatHeader, style: headerStyle))),
-                      const DataColumn(label: Expanded(child: Text("", style: headerStyle))),
-                      DataColumn(label: Expanded(child: Text(AppLocalizations.of(context)!.resolutionHeader, style: headerStyle))),
-                      DataColumn(label: Expanded(child: Text(AppLocalizations.of(context)!.fpsHeader, style: headerStyle))),
-                      const DataColumn(label: Expanded(child: Text("", style: headerStyle))),
-                      DataColumn(label: Expanded(child: Text(AppLocalizations.of(context)!.sizeHeader, style: headerStyle))),
-                      const DataColumn(label: Expanded(child: Text("", style: headerStyle))),
-                    ],
-                    rows: rows,
-                  ),
-                ],
+    // RepaintBoundary: once rasterized, the table is cached as a layer and is
+    // not re-rasterized on unrelated repaints (progress bar ticking, etc.).
+    return RepaintBoundary(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.filesForThisRecording,
+                style: const TextStyle(fontWeight: FontWeight.bold),
               ),
-            ),
-          );
+              // Raw Table instead of DataTable: no per-cell Material/InkWell
+              // machinery and no heading infrastructure — much cheaper to build
+              // and raster. IntrinsicColumnWidth keeps content-sized columns so
+              // the horizontal scroll still works for wide content.
+              Table(
+                defaultColumnWidth: const IntrinsicColumnWidth(),
+                defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+                border: TableBorder(
+                  horizontalInside: BorderSide(width: 1, color: Theme.of(context).dividerColor),
+                ),
+                children: rows,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/media/media_details.dart
+++ b/lib/src/media/media_details.dart
@@ -95,6 +95,7 @@ class _MediaDetailsViewState extends ConsumerState<MediaDetailsView> {
   Duration? _currentPosition; // Local position override
   bool _formatsExpanded = false; // Tracks if formats section is expanded
   bool _showTables = false; // Delay tables rendering until animation completes
+  Animation<double>? _routeAnimation; // Page transition animation, used to defer heavy work
 
   static const _updatePullPeriod = Duration(seconds: 3);
 
@@ -104,16 +105,18 @@ class _MediaDetailsViewState extends ConsumerState<MediaDetailsView> {
 
     _mpvSocketPath = "/tmp/${widget.id}";
 
+    // Defer table rendering and the first server refresh until the page
+    // transition animation has finished, so nothing competes with it for the
+    // frame budget. Gating on the real route animation (instead of a fixed
+    // 300ms timer) adapts to the actual transition duration and refresh rate.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _pullRefresh();
-      // Delay tables rendering to avoid impacting page transition animation
-      Future.delayed(const Duration(milliseconds: 300), () {
-        if (mounted) {
-          setState(() {
-            _showTables = true;
-          });
-        }
-      });
+      if (!mounted) return;
+      final anim = _routeAnimation = ModalRoute.of(context)?.animation;
+      if (anim == null || anim.status == AnimationStatus.completed || anim.status == AnimationStatus.dismissed) {
+        _onTransitionFinished();
+      } else {
+        anim.addStatusListener(_onRouteAnimStatus);
+      }
     });
 
     _updatePullSubs = Stream.periodic(_updatePullPeriod).listen((event) {
@@ -125,8 +128,25 @@ class _MediaDetailsViewState extends ConsumerState<MediaDetailsView> {
     });
   }
 
+  void _onRouteAnimStatus(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      _routeAnimation?.removeStatusListener(_onRouteAnimStatus);
+      _onTransitionFinished();
+    }
+  }
+
+  // Runs once the page transition animation has settled.
+  void _onTransitionFinished() {
+    if (!mounted) return;
+    setState(() {
+      _showTables = true;
+    });
+    _pullRefresh();
+  }
+
   @override
   void deactivate() {
+    _routeAnimation?.removeStatusListener(_onRouteAnimStatus);
     _updatePullSubs?.cancel();
     _rewindTimer?.cancel();
     super.deactivate();
@@ -483,6 +503,8 @@ class _MediaDetailsViewState extends ConsumerState<MediaDetailsView> {
     await ref.read(recordingNotifierProvider(widget.id).notifier).refreshFromServer();
     await ref.read(downloadsNotifierProvider(widget.id).notifier).refreshFromServer();
 
+    // The refreshes above are async; the page may have been popped meanwhile.
+    if (!mounted) return;
     // Reset local position after server refresh
     setState(() {
       _currentPosition = null;
@@ -732,7 +754,14 @@ class _MediaDetailsViewState extends ConsumerState<MediaDetailsView> {
                 child: Stack(
                   alignment: Alignment.center,
                   children: [
-                    createThumb(ref, recording.thumbnailUrl),
+                    createThumb(
+                      ref,
+                      recording.thumbnailUrl,
+                      // Decode to screen width in physical pixels instead of the
+                      // full source resolution — avoids a decode spike on the
+                      // first detail frame during the transition.
+                      cacheWidth: (MediaQuery.of(context).size.width * MediaQuery.of(context).devicePixelRatio).round(),
+                    ),
                     // Current position display (top center)
                     Positioned(
                       top: 16,

--- a/lib/src/media/media_list.dart
+++ b/lib/src/media/media_list.dart
@@ -23,7 +23,7 @@ import 'media_add.dart';
 import 'media_details.dart';
 import 'media_kit/audio_handler.dart';
 
-Widget createThumb(WidgetRef ref, String url) {
+Widget createThumb(WidgetRef ref, String url, {int? cacheWidth}) {
   late Widget thumbWidget;
   if (UniversalPlatform.isWeb) {
     thumbWidget = Image.network(
@@ -31,6 +31,7 @@ Widget createThumb(WidgetRef ref, String url) {
       isAntiAlias: true,
       filterQuality: FilterQuality.high,
       fit: BoxFit.fitWidth,
+      cacheWidth: cacheWidth,
     );
   } else {
     final thumbProvider = ref.watch(thumbnailDataNotifierProvider(url));
@@ -41,6 +42,7 @@ Widget createThumb(WidgetRef ref, String url) {
       thumbWidget = Image.memory(
         thumbProvider.requireValue,
         fit: BoxFit.fitWidth,
+        cacheWidth: cacheWidth,
       );
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Ilovlya Media Center
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 3.6.8
+version: 3.6.9
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## What

Eliminates the jank when opening a recording's details page from the list.

## Why

Opening a recording dropped ~6 frames once server data arrived (build ~90 ms, raster ~85 ms): the downloads table is a `DataTable` that builds and rasterizes every row synchronously right after the slide. Confirmed from both sides — with the server unreachable (table not rendered) the transition was already smooth.

## Changes

- Replace the downloads `DataTable` with a lightweight `Table` wrapped in a `RepaintBoundary`; horizontal scroll preserved via `IntrinsicColumnWidth`.
- Gate the details tables on the route transition animation completing (instead of a fixed 300 ms timer); defer the first server refresh past the animation.
- Decode the details thumbnail to screen width (`cacheWidth`) instead of full source resolution.
- Guard `_pullRefresh`'s `setState` with a `mounted` check — fixes a crash (`Null check operator used on a null value`) when navigating back before the async refresh completes.
- Bump version to 3.6.9.

## Measurements (iPhone 15 Pro, profile mode)

Transition peak: build **90 → 13 ms**, raster **66–89 ms → max 3.3 ms**, **zero** janky frames.

## Follow-up (separate task)

Returning from the embedded player to the details card still freezes ~0.5–0.9 s. Profiling showed this is a native media_kit/libmpv video-texture teardown (Dart `deactivate` measured 0 ms), not a Flutter render cost — likely addressed by reusing a single `VideoController` instead of recreating it on every open. Tracked separately.
