### PR TITLE
⚡️ perf(player): smooth the return transition from the player screen

### DIFF
--- a/lib/src/media/media_kit/audio_handler.dart
+++ b/lib/src/media/media_kit/audio_handler.dart
@@ -1,6 +1,7 @@
 import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_video/media_kit_video.dart';
 import 'package:universal_platform/universal_platform.dart';
 
 import '../../model/download.dart';
@@ -21,6 +22,17 @@ class MKPlayerHandler extends BaseAudioHandler with SeekHandler {
     logLevel: MPVLogLevel.info,
     osc: false,
   ));
+
+  // Single shared video controller, reused across every open/close of the
+  // player screen. Recreating a VideoController per open (and letting it be
+  // torn down on close) caused a ~0.5-0.9s native video-output teardown that
+  // froze the return transition. Created lazily on first playback and kept for
+  // the app lifetime so the texture is never re-created/destroyed on the fly.
+  static VideoController get videoController => _handler._videoController;
+  late final VideoController _videoController = VideoController(
+    _player,
+    configuration: const VideoControllerConfiguration(enableHardwareAcceleration: true),
+  );
 
   bool _wasPlayingBeforeInterruption = false;
 

--- a/lib/src/media/media_kit/recording_play.dart
+++ b/lib/src/media/media_kit/recording_play.dart
@@ -62,7 +62,9 @@ const _positionSendPeriod = Duration(seconds: 1);
 class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMediaKitHandler> {
   // String get url => widget.download.url;
   Player get _player => MKPlayerHandler.player;
-  late final _controller = VideoController(_player, configuration: VideoControllerConfiguration(enableHardwareAcceleration: true));
+  // Shared, app-lifetime controller (see MKPlayerHandler.videoController):
+  // avoids per-open video-output creation/teardown that froze the return.
+  VideoController get _controller => MKPlayerHandler.videoController;
   StreamSubscription? _positionSendSubs;
   StreamSubscription? _uiUpdateSubs;
   Duration _rewinding = Duration.zero;
@@ -281,11 +283,17 @@ class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMedi
   }
 
   @override
-  void deactivate() async {
-    MKPlayerHandler.player.stop();
-    MKPlayerHandler.clearMediaSession(); // Clear lock screen notification
+  void deactivate() {
+    // Stop UI-updating streams immediately.
     _positionSendSubs?.cancel();
     _uiUpdateSubs?.cancel();
+    // Defer the native player teardown until after the pop transition. The
+    // native stop() (releasing the HW video decoder) otherwise blocks the
+    // platform thread during the reverse slide, causing a visible jerk.
+    Future.delayed(const Duration(milliseconds: 400), () {
+      MKPlayerHandler.player.stop();
+      MKPlayerHandler.clearMediaSession(); // Clear lock screen notification
+    });
     super.deactivate();
   }
 
@@ -354,16 +362,26 @@ class _RecordingViewMediaKitHandlerState extends ConsumerState<RecordingViewMedi
     // final rewindTextStyle = Theme.of(context).textTheme.titleSmall;
     final techInfoStyle = GoogleFonts.ptMono();
     return PopScope(
-      onPopInvokedWithResult: (bool didPop, Object? result) async {
+      onPopInvokedWithResult: (bool didPop, Object? result) {
         final updateThumbnails = ref.read(settingsNotifierProvider.select((value) => value.requireValue.updateThumbnails));
-        if (!UniversalPlatform.isWeb && updateThumbnails) {
-          MKPlayerHandler.player.screenshot(format: "image/png").then((imgData) {
-            ref.read(thumbnailDataNotifierProvider(widget.recording.thumbnailUrl).notifier).updateThumbnailImg(imgData);
-          });
-        }
-
-        ref.invalidate(recordingNotifierProvider(widget.recording.id));
-        ref.invalidate(mediaListNotifierProvider);
+        // Capture the container now: `ref` becomes invalid once this widget is
+        // disposed by the pop, but the container outlives it.
+        final container = ProviderScope.containerOf(context, listen: false);
+        final recId = widget.recording.id;
+        final thumbUrl = widget.recording.thumbnailUrl;
+        // Defer the teardown (thumbnail screenshot + provider invalidations)
+        // past the pop transition. Run synchronously here it rebuilds/refetches
+        // the details and the whole media list underneath, blocking the button's
+        // programmatic pop animation (a swipe hides it — it is finger-driven).
+        Future.delayed(const Duration(milliseconds: 350), () {
+          if (!UniversalPlatform.isWeb && updateThumbnails) {
+            MKPlayerHandler.player.screenshot(format: "image/png").then((imgData) {
+              container.read(thumbnailDataNotifierProvider(thumbUrl).notifier).updateThumbnailImg(imgData);
+            });
+          }
+          container.invalidate(recordingNotifierProvider(recId));
+          container.invalidate(mediaListNotifierProvider);
+        });
       },
       child: Scaffold(
         // appBar: AppBar(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Ilovlya Media Center
 # Prevent accidental publishing to pub.dev.
 publish_to: 'none'
 
-version: 3.6.9
+version: 3.6.10
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## What

Smooths the return transition from the embedded player back to the details card. Previously the reverse transition froze — the **back button** showed no animation at all, and swipe-back hid it only because the gesture is finger-driven.

## Root cause

Profiling showed native/synchronous teardown running on the pop, not a Flutter render cost (`deactivate` measured 0 ms; frame build/raster were tiny). Two synchronous costs on the pop path:

- A new `VideoController` (native video output/texture) was created on every player open and torn down on close.
- `PopScope.onPopInvokedWithResult` **unconditionally** invalidated `mediaListNotifierProvider` (refetch + rebuild of the whole list underneath) right as the button's programmatic pop animation started — eating the animation.

## Changes

- **Reuse a single app-lifetime `VideoController`** in `MKPlayerHandler` instead of recreating one per open (also fixes a controller leak). → smooths player **open**.
- **Defer `player.stop()` / media-session clear** in `deactivate()` past the pop so the native stop does not block the reverse slide. → smooths **swipe** back.
- **Defer the `PopScope` teardown** (thumbnail screenshot + recording/media-list invalidations) past the pop. → restores the **back-button** pop animation.
- Bump version to 3.6.10.

## Status

Validated on device (iPhone 15 Pro, profile): player open smooth, swipe-back smooth, back-button animation restored. Author is dogfooding for a few days before final sign-off.

Follow-up context: this addresses the player-return freeze noted in #108.
